### PR TITLE
feat: use Rollbar.Configuration and implement all logger methods

### DIFF
--- a/lib/config.interface.ts
+++ b/lib/config.interface.ts
@@ -1,4 +1,0 @@
-export interface IRollbarConfig {
-	accessToken: string;
-	environment: string;
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 export * from './logger.module';
-export * from './config.interface';
 export * from './rollbar.logger';
 export * from './decorators/rollbar.decorator';
 export * from './interfaces/rollbar-options.interface';

--- a/lib/logger.module.ts
+++ b/lib/logger.module.ts
@@ -1,14 +1,14 @@
 import { Module, DynamicModule, Provider, Global } from '@nestjs/common';
 import { RollbarLogger } from './rollbar.logger';
-import { IRollbarConfig } from './config.interface';
+import { Configuration as RollbarOptions } from 'rollbar';
 
 export let logger: RollbarLogger;
 
 @Global()
 @Module({})
 export class LoggerModule {
-	static forRoot(config: IRollbarConfig): DynamicModule {
-		logger = new RollbarLogger(config);
+	static forRoot(options: RollbarOptions): DynamicModule {
+		logger = new RollbarLogger(options);
 		const loggerServiceProvider: Provider = {
 			provide: RollbarLogger,
 			useFactory: () => logger,

--- a/lib/rollbar.logger.ts
+++ b/lib/rollbar.logger.ts
@@ -1,20 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { LoggerService } from '@nestjs/common';
 import * as Rollbar from 'rollbar';
-import { IRollbarConfig } from './config.interface';
 
-export class RollbarLogger extends Logger {
-	rollbar;
-
-	constructor({ accessToken, environment }: IRollbarConfig) {
-		super();
-		this.rollbar = new Rollbar({
-			accessToken,
-			environment,
-		});
-	}
-
-	error(error: Error, context?: string) {
-		this.rollbar.error(error);
-		super.error(error.message, null, context);
-	}
-}
+export class RollbarLogger extends Rollbar implements LoggerService {}


### PR DESCRIPTION
RollbarLogger can extend Rollbar, since it implements the minimum requirements of LoggerService and has additional methods.  This gives users full access to the Rollbar API.

Resolves #3 